### PR TITLE
Add Retry Functionality to the API Call

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,10 +12,10 @@ def fetch_external_data(url, retries=3, backoff=2):
     Returns:
         dict or None: Parsed JSON data, or None if all retries fail.
     """
-    attempt = 0
-    while attempt < retries:
+    attempt = 0;
+    while attempt < retries
         try:
-            response = requests.get(url, timeout=5)
+            response = requests.get(url, timeout=5);
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:

--- a/app.py
+++ b/app.py
@@ -1,19 +1,25 @@
 import requests
 
-def fetch_external_data(url):
+def fetch_external_data(url, retries=3, backoff=2):
     """
-    Fetches data from an external API.
-
+    Fetches data from an external API with retry logic.
+    
     Parameters:
         url (str): The API endpoint to fetch data from.
-
+        retries (int): Number of retries before giving up.
+        backoff (int): Time multiplier for exponential backoff.
+        
     Returns:
-        dict or None: Parsed JSON data, or None if the request fails.
+        dict or None: Parsed JSON data, or None if all retries fail.
     """
-    try:
-        response = requests.get(url, timeout=5)
-        response.raise_for_status()
-        return response.json()
-    except requests.RequestException as e:
-        print(f"API call failed: {e}")
-        return None
+    attempt = 0
+    while attempt < retries:
+        try:
+            response = requests.get(url, timeout=5)
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            print(f"[Retry {attempt+1}] Error: {e}")
+            time.sleep(backoff ** attempt)
+            attempt += 1
+    return None

--- a/logging.py
+++ b/logging.py
@@ -1,0 +1,21 @@
+import logging
+
+# Set up basic config (can be extended later)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler("service.log"),
+        logging.StreamHandler()
+    ]
+)
+
+def log_retry(attempt, error):
+    """
+    Logs retry attempts in a consistent format.
+
+    Parameters:
+        attempt (int): The current retry attempt number.
+        error (Exception): The exception raised during the attempt.
+    """
+    logging.warning(f"[Retry {attempt}] API call failed: {error}")


### PR DESCRIPTION
This PR adds a retry mechanism to the `fetch_external_data()` function in case the external API call fails due to transient errors. It uses the `requests` library with exponential backoff.

Also added basic logging for retries.

- Improves system resiliency
- Adds minimal latency overhead